### PR TITLE
added config value to set stack size on Dream managed threads

### DIFF
--- a/src/MindTouchDream.4.5.resharper
+++ b/src/MindTouchDream.4.5.resharper
@@ -83,9 +83,7 @@
       </Naming2>
     </CSharp>
     <VB>
-      <FormatSettings>
-        <INDENT_SIZE>4</INDENT_SIZE>
-      </FormatSettings>
+      <FormatSettings />
       <ImportsSettings />
       <Naming2 />
     </VB>

--- a/src/mindtouch.dream/Threading/DispatchThread.cs
+++ b/src/mindtouch.dream/Threading/DispatchThread.cs
@@ -55,7 +55,9 @@ namespace MindTouch.Threading {
         internal DispatchThread() {
 
             // create new thread
-            Thread thread = new Thread(DispatchLoop) { IsBackground = true };
+            var thread = Async.MaxStackSize.HasValue
+                ? new Thread(DispatchLoop, Async.MaxStackSize.Value) { IsBackground = true }
+                : new Thread(DispatchLoop) { IsBackground = true };
 
             //  assign ID
             _id = thread.ManagedThreadId;
@@ -95,7 +97,7 @@ namespace MindTouch.Threading {
                 _host = value;
             }
         }
-        
+
         //--- Methods ---
         public bool TryStealWorkItem(out Action callback) {
             return _inbox.TrySteal(out callback);
@@ -148,7 +150,7 @@ namespace MindTouch.Threading {
                         if(_host == null) {
 
                             // NOTE (steveb): this is a brand new thread without a host yet
-                            
+
                             // return the thread to the dispatch scheduler
                             DispatchThreadScheduler.ReleaseThread(this, result);
                         } else {


### PR DESCRIPTION
Since IIS hardcodes the stack size to 256KB instead of the usual 1024KB, i've added an option for setting the stack size to be used by threads created via DReAM's fork methods or threadpool
