### PR TITLE
issuing special internal cookie for local service creation

### DIFF
--- a/src/mindtouch.dream/Web/DreamCookie.cs
+++ b/src/mindtouch.dream/Web/DreamCookie.cs
@@ -639,7 +639,7 @@ namespace MindTouch.Web {
         public string Domain {
             get { return Uri == null ? null : Uri.HostPort; }
         }
-        
+
         /// <summary>
         /// Cookie Path.
         /// </summary>
@@ -726,6 +726,32 @@ namespace MindTouch.Web {
                     .Attr("version", 1)
                     .Elem("name", Name)
                     .Elem("uri", Uri)
+                    .Elem("value", Value);
+                if(Expires < DateTime.MaxValue) {
+                    result.Elem("expires", Expires);
+                }
+                if(!string.IsNullOrEmpty(Comment)) {
+                    result.Elem("comment", Comment);
+                }
+                if(CommentUri != null) {
+                    result.Elem("uri.comment", CommentUri.ToString());
+                }
+                if(Discard) {
+                    result.Attr("discard", true);
+                }
+                if(Secure) {
+                    result.Attr("secure", true);
+                }
+                return result;
+            }
+        }
+
+        internal XDoc AsInternalSetCookieDocument {
+            get {
+                XDoc result = new XDoc("set-cookie")
+                    .Attr("version", 1)
+                    .Elem("name", Name)
+                    .Elem("uri", Uri.AsLocalUri().ToString())
                     .Elem("value", Value);
                 if(Expires < DateTime.MaxValue) {
                     result.Elem("expires", Expires);

--- a/src/mindtouch.dream/dream/servicebase.cs
+++ b/src/mindtouch.dream/dream/servicebase.cs
@@ -809,7 +809,7 @@ namespace MindTouch.Dream {
                 .Elem("uri.owner", Self.Uri.ToString())
 
                 // add 'internal' access key
-                .Add(DreamCookie.NewSetCookie("service-key", InternalAccessKey, Self.Uri).AsSetCookieDocument)
+                .Add(DreamCookie.NewSetCookie("service-key", InternalAccessKey, Self.Uri).AsInternalSetCookieDocument)
 
                 // add optional 'service-license' token
                 .Elem("service-license", serviceLicense);


### PR DESCRIPTION
This normalizes internal service creation requests to use both owner and set-cookie local uri's (instead of mixed local and public)
