### PR TITLE
host listener now uses the supplied port

### DIFF
--- a/src/mindtouch.core/DreamHost.cs
+++ b/src/mindtouch.core/DreamHost.cs
@@ -187,10 +187,10 @@ namespace MindTouch.Dream {
                 // check if user prescribed a set of IP addresses to use
                 if(addresses != null) {
 
-                    // listen to custom addresses (don't use the supplied port info, we expect that to be part of the address)
+                    // listen to custom addresses
                     foreach(string address in addresses) {
                         if(!StringUtil.EqualsInvariantIgnoreCase(address, "localhost")) {
-                            AddListener(new XUri(String.Format("http://{0}/", address)), authenticationScheme);
+                            AddListener(new XUri(String.Format("http://{0}:{1}/", address, httpPort)), authenticationScheme);
                         }
                     }
                 } else {


### PR DESCRIPTION
The host listener expects the port to be provided with the hostname. I think re-using the port supplied with http-port is clearer.
