### PR TITLE
Use text/plain Content-Type if the Content-type is present but invalid

### DIFF
--- a/src/mindtouch.dream/plug/HttpPlugEndpoint.cs
+++ b/src/mindtouch.dream/plug/HttpPlugEndpoint.cs
@@ -333,7 +333,7 @@ namespace MindTouch.Dream.Http {
             // Let's default to TEXT if the ContentType is invalid
             if(!string.IsNullOrEmpty(httpResponse.ContentType) && !MimeType.TryParse(httpResponse.ContentType, out contentType)) {
                _log.WarnFormat("Invalid Content Type : '{0}', using plain/text as default",httpResponse.ContentType);
-               contentType = MimeType.TEXT;
+               contentType = MimeType.DefaultMimeType;
             }
 
             Stream stream;

--- a/src/mindtouch.dream/plug/HttpPlugEndpoint.cs
+++ b/src/mindtouch.dream/plug/HttpPlugEndpoint.cs
@@ -328,7 +328,14 @@ namespace MindTouch.Dream.Http {
             }
 
             // determine response type
-            MimeType contentType = string.IsNullOrEmpty(httpResponse.ContentType) ? null : new MimeType(httpResponse.ContentType);
+            MimeType contentType = null;
+
+            // Let's default to TEXT if the ContentType is invalid
+            if(!string.IsNullOrEmpty(httpResponse.ContentType) && !MimeType.TryParse(httpResponse.ContentType, out contentType)) {
+               _log.WarnFormat("Invalid Content Type : '{0}', using plain/text as default",httpResponse.ContentType);
+               contentType = MimeType.TEXT;
+            }
+
             Stream stream;
             HttpStatusCode statusCode = httpResponse.StatusCode;
             WebHeaderCollection headers = httpResponse.Headers;

--- a/src/mindtouch.dream/plug/HttpPlugEndpoint.cs
+++ b/src/mindtouch.dream/plug/HttpPlugEndpoint.cs
@@ -330,9 +330,9 @@ namespace MindTouch.Dream.Http {
             // determine response type
             MimeType contentType = null;
 
-            // Let's default to TEXT if the ContentType is invalid
+            // Use MimeType.DefaultMimeType if the ContentType is invalid
             if(!string.IsNullOrEmpty(httpResponse.ContentType) && !MimeType.TryParse(httpResponse.ContentType, out contentType)) {
-               _log.WarnFormat("Invalid Content Type : '{0}', using plain/text as default",httpResponse.ContentType);
+               _log.WarnFormat("Invalid Content Type : '{0}', using '{1}' as default",httpResponse.ContentType,MimeType.DefaultMimeType);
                contentType = MimeType.DefaultMimeType;
             }
 


### PR DESCRIPTION

Pull Request to fix bug : DR-93 Invalid server Content-Type should'nt return HTTP Status: UnableToConnect 

Thanks