### PR TITLE
separate out log4net settings into a separate file

### DIFF
--- a/src/mindtouch.host/App.config
+++ b/src/mindtouch.host/App.config
@@ -5,6 +5,7 @@
   </configSections>
   <appSettings>
     <add key="threadpool" value="elastic" />
+    <add key="log4net.Config" value="log4net.config"/>
   </appSettings>
   <system.net>
     <connectionManagement>
@@ -12,19 +13,6 @@
       <add address="*" maxconnection="16" />
     </connectionManagement>
   </system.net>
-  <log4net>
-    <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
-      </layout>
-    </appender>
-    <renderer renderingClass="MindTouch.Logging.ExceptionRenderer" renderedClass="System.Exception" />
-    <!-- Set root logger level to DEBUG and its only appender to A1 -->
-    <root>
-      <level value="WARN" />
-      <appender-ref ref="ConsoleAppender" />
-    </root>
-  </log4net>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/src/mindtouch.host/log4net.config
+++ b/src/mindtouch.host/log4net.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
+    </layout>
+  </appender>
+  <renderer renderingClass="MindTouch.Logging.ExceptionRenderer" renderedClass="System.Exception" />
+  <!-- Set root logger level to WARN and its only appender to ConsoleAppender  -->
+  <root>
+    <level value="WARN" />
+    <appender-ref ref="ConsoleAppender" />
+  </root>
+</log4net>

--- a/src/mindtouch.host/mindtouch.host.csproj
+++ b/src/mindtouch.host/mindtouch.host.csproj
@@ -62,6 +62,9 @@
   <ItemGroup>
     <None Include="App.config">
     </None>
+    <None Include="log4net.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="mindtouch.env.xml">


### PR DESCRIPTION
Steve/Arne - Having a separate log4net.config would make my life easier by allowing puppet to mange the log4net.config for different environments without hacking stuff up with sed.  Thoughts?
