### PR TITLE
Removed obsolete TODO comments

### DIFF
--- a/src/tests/DreamMisc/DreamHostTest.cs
+++ b/src/tests/DreamMisc/DreamHostTest.cs
@@ -250,9 +250,6 @@ namespace MindTouch.Dream.Test {
         [Test]
         [ExpectedException(typeof(DreamResponseException))]
         public void BadHostRequest() {
-
-            // TODO (steveb): test fails under Mono 2.8.2
-
             Plug plug = Plug.New("http://nowhere/foo");
             plug.Get();
         }
@@ -373,9 +370,6 @@ namespace MindTouch.Dream.Test {
 
         [Test]
         public void Hitting_connect_limit_returns_service_unavailable() {
-
-            // TODO (steveb): test fails under Mono 2.8.2
-
             int connectLimit = 5;
             using(var hostInfo = DreamTestHelper.CreateRandomPortHost(new XDoc("config").Elem("connect-limit", connectLimit))) {
                 var mockService = MockService.CreateMockService(hostInfo);

--- a/src/tests/DreamMisc/Service2ServiceTests.cs
+++ b/src/tests/DreamMisc/Service2ServiceTests.cs
@@ -47,9 +47,6 @@ namespace MindTouch.Dream.Test {
 
         [Test]
         public void Setting_ip_for_host_registers_public_alias() {
-			
-			// TODO (steveb): test fails under Mono 2.8.2
-			
             int hitCounter = 0;
             _service1.Service.CatchAllCallback = delegate(DreamContext context, DreamMessage request, Result<DreamMessage> r) {
                 hitCounter++;


### PR DESCRIPTION
Removed obsolete TODO comments relating to failing tests that now pass on mono 2.10.11
