### PR TITLE
DR-108 MindTouch.Web.HttpUtil.GetAuthentication() throws exception with Authorization header is not properly Base64 encoded

### DIFF
--- a/src/mindtouch.dream/Web/HttpUtil.cs
+++ b/src/mindtouch.dream/Web/HttpUtil.cs
@@ -227,8 +227,7 @@ namespace MindTouch.Web {
                         password = (userPwd.Length > 1) ? userPwd[1] : string.Empty;
                         return true;
                     } catch {
-                        
-                        // unable to decode authorization header
+                        throw new InvalidHttpAuthorizationHeader();
                     }
                 }
             }
@@ -275,10 +274,12 @@ namespace MindTouch.Web {
                     // add language option
                     choices.Add(new Tuplet<string, double>(name, quality));
                 }
+
+                // reverse order sort based on quality
                 choices.Sort((left, right) => Math.Sign(right.Item2 - left.Item2));
 
                 // find the first acceptable language
-                foreach(var t in choices) {
+                foreach(var choice in choices) {
 
                     // check for wildcard
                     if(choices[0].Item1 == "*") {
@@ -286,7 +287,7 @@ namespace MindTouch.Web {
                     }
 
                     // expand language to full culture
-                    var culture = CultureUtil.GetNonNeutralCulture(t.Item1);
+                    var culture = CultureUtil.GetNonNeutralCulture(choice.Item1);
                     if(culture != null) {
                         return culture;
                     }

--- a/src/mindtouch.dream/Web/InvalidHttpAuthorizationHeader.cs
+++ b/src/mindtouch.dream/Web/InvalidHttpAuthorizationHeader.cs
@@ -1,0 +1,26 @@
+/*
+ * MindTouch Dream - a distributed REST framework 
+ * Copyright (C) 2006-2013 MindTouch, Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * For community documentation and downloads visit wiki.developer.mindtouch.com;
+ * please review the licensing section.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace MindTouch.Web {
+    public class InvalidHttpAuthorizationHeader : Exception { }
+}

--- a/src/mindtouch.dream/mindtouch.dream.csproj
+++ b/src/mindtouch.dream/mindtouch.dream.csproj
@@ -290,6 +290,7 @@
     <Compile Include="Threading\SynchronizationDispatchQueue.cs" />
     <Compile Include="Threading\Timer\GlobalClock.cs" />
     <Compile Include="Web\HttpUtil.cs" />
+    <Compile Include="Web\InvalidHttpAuthorizationHeader.cs" />
     <Compile Include="Xml\XAtom.cs" />
     <Compile Include="Xml\XDoc.cs" />
     <Compile Include="Xml\XDocCop.cs" />


### PR DESCRIPTION
Reviewed by ArneC
Ticket: http://youtrack.developer.mindtouch.com/issue/DR-108
