### PR TITLE
DR-117 Optimize XUri parser

### DIFF
--- a/src/mindtouch.dream/Tasking/coroutine.cs
+++ b/src/mindtouch.dream/Tasking/coroutine.cs
@@ -176,6 +176,11 @@ namespace MindTouch.Tasking {
     /// a method's signature must match one of the <see cref="CoroutineHandler{TResult}"/> delegates, i.e. it will always have a
     /// return type of <see cref="IEnumerator{T}"/> and the last argument is always a subclass of <see cref="AResult"/>.
     /// </remarks>
+ 
+    // NOTE (steveb): Coroutine requires the Serializable attribute, because it is referenced by exception instances, which
+    //                require their additional information to be serializalbe.  DO NOT REMOVE!
+    [Serializable]
+
     public sealed class Coroutine : IContinuation {
 
         //--- Class Fields ---

--- a/src/tests/DreamMisc/Service2ServiceTests.cs
+++ b/src/tests/DreamMisc/Service2ServiceTests.cs
@@ -75,7 +75,7 @@ namespace MindTouch.Dream.Test {
             };
             var response = Plug.New(_service1.AtLocalHost.Uri.WithHost("foo").WithPort(80)).GetAsync().Wait();
             Assert.IsTrue(response.IsSuccessful);
-            Assert.AreEqual("foo", receivedHost);
+            Assert.AreEqual("foo:80", receivedHost);
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace MindTouch.Dream.Test {
             };
             var response = _service1.AtLocalHost.GetAsync().Wait();
             Assert.IsTrue(response.IsSuccessful);
-            Assert.AreEqual("foo", receivedHost);
+            Assert.AreEqual("foo:80", receivedHost);
         }
     }
 }

--- a/src/tests/DreamMisc/XUri-Test.cs
+++ b/src/tests/DreamMisc/XUri-Test.cs
@@ -1066,6 +1066,36 @@ namespace MindTouch.Dream.Test {
             Assert.AreNotEqual(resultHttp, resultHttps);
         }
 
+        [Test]
+        public void Changing_scheme_with_explicit_default_port_keeps_port() {
+            var uri = XUri.TryParse("http://example.com:80");
+            Assert.AreEqual(80, uri.Port, "original port");
+            Assert.AreEqual("http://example.com:80", uri.ToString(), "original uri");
+            uri = uri.WithScheme("https");
+            Assert.AreEqual(80, uri.Port, "new port");
+            Assert.AreEqual("https://example.com:80", uri.ToString(), "new uri");
+        }
+
+        [Test]
+        public void Changing_scheme_with_explicit_custom_port_keeps_port() {
+            var uri = XUri.TryParse("http://example.com:81");
+            Assert.AreEqual(81, uri.Port, "original port");
+            Assert.AreEqual("http://example.com:81", uri.ToString(), "original uri");
+            uri = uri.WithScheme("https");
+            Assert.AreEqual(81, uri.Port, "new port");
+            Assert.AreEqual("https://example.com:81", uri.ToString(), "new uri");
+        }
+
+        [Test]
+        public void Changing_scheme_with_implicit_port_hides_port() {
+            var uri = XUri.TryParse("http://example.com");
+            Assert.AreEqual("http://example.com", uri.ToString(), "original uri");
+            Assert.AreEqual(80, uri.Port, "original port");
+            uri = uri.WithScheme("https");
+            Assert.AreEqual(80, uri.Port, "port");
+            Assert.AreEqual("https://example.com", uri.ToString(), "new uri");
+        }
+
         private void AssertRelative(string uri, string relative, string common) {
             var x = new XUri(uri).GetRelativePathTo(new XUri(relative));
             Assert.AreEqual(common, x, string.Format("{0} relative to {1}", uri, relative));


### PR DESCRIPTION
- Couroutine: added [Serializable] and comment that explains why this attribute is needed
- Updated unit tests, because XUri::WithPort(int) behaves slightly differently
- Added new unit tests to confirm behavior of XUri::WithPort(int)
