### PR TITLE
Fixing off by one error in Dream

### DIFF
--- a/src/mindtouch.dream/Collections/EnumerableUtil.cs
+++ b/src/mindtouch.dream/Collections/EnumerableUtil.cs
@@ -103,7 +103,7 @@ namespace MindTouch {
             var chunk = new List<T>(chunkSize);
             foreach(var x in source) {
                 chunk.Add(x);
-                if(chunk.Count <= chunkSize) {
+                if(chunk.Count < chunkSize) {
                     continue;
                 }
                 yield return chunk;

--- a/src/tests/DreamMisc/Collections/EnumerableUtilTests/Split.cs
+++ b/src/tests/DreamMisc/Collections/EnumerableUtilTests/Split.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * MindTouch Dream - a distributed REST framework 
+ * Copyright (C) 2006-2014 MindTouch, Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * For community documentation and downloads visit wiki.developer.mindtouch.com;
+ * please review the licensing section.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Linq;
+using NUnit.Framework;
+
+namespace MindTouch.Dream.Test.Collections.EnumerableUtilTests {
+    
+    [TestFixture]
+    public class Split {
+
+        [Test]
+        public void Split_generates_chunks_of_specified_length() {
+            
+            // Arrange
+            var array = Enumerable.Range(0, 1000);
+
+            // Act
+            var chunks = array.Split(100);
+
+            // Assert
+            foreach(var c in chunks) {
+                Assert.AreEqual(100, c.Count(), "Chunk size is incorrect");
+            }
+        }
+
+        [Test]
+        public void Split_can_handle_one_element() {
+
+            // Arrange
+            var array = new[] { 1 };
+
+            // Act
+            var chunks = array.Split(100);
+
+            // Assert
+            Assert.AreEqual(1, chunks.Count(), "There should only be one chunk");
+            Assert.AreEqual(1, chunks.First().Count(), "Chunk should only contain one element");
+        }
+    }
+}

--- a/src/tests/DreamMisc/test.mindtouch.dream.csproj
+++ b/src/tests/DreamMisc/test.mindtouch.dream.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Aws\MockSqsClient.cs" />
     <Compile Include="BlockingQueueTests.cs" />
     <Compile Include="ChunkedArrayTests.cs" />
+    <Compile Include="Collections\EnumerableUtilTests\Split.cs" />
     <Compile Include="ContainerTests.cs" />
     <Compile Include="Collections\LockFreeItemConsumerQueueTests.cs" />
     <Compile Include="Collections\LockFreeQueueTests.cs" />


### PR DESCRIPTION
https://youtrack.mindtouch.us/issue/DR-123
Reviewed by Steve

Problem:
When using .Split<T>(chunkSize)
The chunks generated have size of chunkSize+1

Solution:
Fix off by 1 error
