### PR TITLE
DR-142 Include Background Thread Pool stats in the /@api/host/status route.

### DIFF
--- a/src/mindtouch.core/DreamHostService.cs
+++ b/src/mindtouch.core/DreamHostService.cs
@@ -690,17 +690,21 @@ namespace MindTouch.Dream {
             int workerThreads;
             int completionThreads;
             int dispatcherThreads;
-            AsyncUtil.GetAvailableThreads(out workerThreads, out completionThreads, out dispatcherThreads);
+            int backgroundWorkerThreads;
+            AsyncUtil.GetAvailableThreads(out workerThreads, out completionThreads, out dispatcherThreads, out backgroundWorkerThreads);
             int maxWorkerThreads;
             int maxCompletionThreads;
             int maxDispatcherThreads;
-            AsyncUtil.GetMaxThreads(out maxWorkerThreads, out maxCompletionThreads, out maxDispatcherThreads);
+            int maxBackgroundWorkerThreads;
+            AsyncUtil.GetMaxThreads(out maxWorkerThreads, out maxCompletionThreads, out maxDispatcherThreads, out maxBackgroundWorkerThreads);
             result.Elem("workerthreads.max", maxWorkerThreads);
             result.Elem("workerthreads.used", maxWorkerThreads - workerThreads);
             result.Elem("completionthreads.max", maxCompletionThreads);
             result.Elem("completionthreads.used", maxCompletionThreads - completionThreads);
             result.Elem("dispatcherthreads.max", maxDispatcherThreads);
             result.Elem("dispatcherthreads.used", maxDispatcherThreads - dispatcherThreads);
+            result.Elem("backgroundworkerthreads.max", maxBackgroundWorkerThreads);
+            result.Elem("backgroundworkerthreads.used", maxBackgroundWorkerThreads - backgroundWorkerThreads);
 
             // timer information
             var taskTimerStats = TaskTimerFactory.GetStatistics();
@@ -1067,7 +1071,8 @@ namespace MindTouch.Dream {
                     int maxThreads;
                     int maxPorts;
                     int maxDispatchers;
-                    AsyncUtil.GetMaxThreads(out maxThreads, out maxPorts, out maxDispatchers);
+                    int maxBackgroundThreads;
+                    AsyncUtil.GetMaxThreads(out maxThreads, out maxPorts, out maxDispatchers, out maxBackgroundThreads);
                     if(maxDispatchers > 0) {
                         _connectionLimit = maxDispatchers + _connectionLimit;
                     } else {

--- a/src/mindtouch.host/ConsoleHostProgram.cs
+++ b/src/mindtouch.host/ConsoleHostProgram.cs
@@ -193,14 +193,17 @@ namespace MindTouch.Dream {
                                     int workerThreads;
                                     int completionThreads;
                                     int dispatcherThreads;
-                                    AsyncUtil.GetAvailableThreads(out workerThreads, out completionThreads, out dispatcherThreads);
+                                    int backgroundThreads;
+                                    AsyncUtil.GetAvailableThreads(out workerThreads, out completionThreads, out dispatcherThreads, out backgroundThreads);
                                     int maxWorkerThreads;
                                     int maxCompletionThreads;
                                     int maxDispatcherThreads;
-                                    AsyncUtil.GetMaxThreads(out maxWorkerThreads, out maxCompletionThreads, out maxDispatcherThreads);
+                                    int maxBackgroundThreads;
+                                    AsyncUtil.GetMaxThreads(out maxWorkerThreads, out maxCompletionThreads, out maxDispatcherThreads, out maxBackgroundThreads);
                                     Console.WriteLine("Thread-pool worker threads available: {0} (max: {1})", workerThreads, maxWorkerThreads);
                                     Console.WriteLine("Thread-pool completion threads available: {0} (max: {1})", completionThreads, maxCompletionThreads);
                                     Console.WriteLine("Dispatcher threads available: {0} (max: {1})", dispatcherThreads, maxDispatcherThreads);
+                                    Console.WriteLine("Thread-pool background worker threads available: {0} (max: {1})", backgroundThreads, maxBackgroundThreads);
 
                                     // show pending/waiting timers
                                     var taskTimerStats = Tasking.TaskTimerFactory.GetStatistics();


### PR DESCRIPTION
http://mindtouch.myjetbrains.com/youtrack/issue/DR-142

Including background worker threads in the status response.

